### PR TITLE
 - ensure same margin is used for all tables

### DIFF
--- a/huiPESTO/PEtab_edit_gui/penGUI_view.py
+++ b/huiPESTO/PEtab_edit_gui/penGUI_view.py
@@ -92,12 +92,16 @@ class MainWindow(QMainWindow):
     def create_table_frame(self, index, label_text="", include_stacked_widget=False):
         frame = QFrame()
         frame_layout = QVBoxLayout(frame)
+        if include_stacked_widget:
+            frame_layout.setContentsMargins(0, 0, 0, 0)
+        else:    
+            frame_layout.setContentsMargins(9, 9, 9, 9)
 
         table_labels = ["Measurement Table", "Observable Table", "Parameter Table", "Condition Table"]
 
         # Label and button layout
         label_layout = QHBoxLayout()
-        label_layout.setContentsMargins(0, 0, 0, 0)
+        label_layout.setContentsMargins(9 if include_stacked_widget else 0, 0, 0, 0)
         label = QLabel(label_text if label_text else table_labels[index])
         label_layout.addWidget(label)
 


### PR DESCRIPTION
this pr fixes the issue, where the condition table / plot would have a different margin than all the rest. 

While i was not able to change the default margin for the stacked widget, i was able to make it look the same. 