### PR TITLE
Require `python-libcombine`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "antimony",
     "python-libsbml",
     "matplotlib",
-    "petab>=0.6.0",
+    "petab[combine]>=0.6.0",
     "qtawesome",
     "copasi-basico",
     "copasi-petab-importer"


### PR DESCRIPTION
Currently, `python-libcombine` is not a requirement, but we rely on it being installed. So, let's require it.

Closes #172.