### PR TITLE
Update .zenodo.json

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -14,8 +14,8 @@
     },
     {
       "name": "Daniel Weindl",
-      "affiliation": "University of Bonn",
-      "orcid": "https://orcid.org/0000-0001-9963-6057"
+      "affiliation": "University Bonn",
+      "orcid": "0000-0001-9963-6057"
     }
   ],
   "keywords": [


### PR DESCRIPTION
#194 fix typo

This makes another PR, ensuring the University of Bonn is written the same, as it is for Paul, and that the orcid really is just the orcid.