### PR TITLE
Updated first start issue

### DIFF
--- a/src/petab_gui/app.py
+++ b/src/petab_gui/app.py
@@ -135,11 +135,17 @@ def main():
     args = parser.parse_args()
 
     if sys.platform == "darwin":
-        from Foundation import NSBundle  # type: type: ignore[import]
+        try:
+            from Foundation import NSBundle  # type: ignore[import]
 
-        bundle = NSBundle.mainBundle()
-        info = bundle.localizedInfoDictionary() or bundle.infoDictionary()
-        info["CFBundleName"] = APP_NAME
+            bundle = NSBundle.mainBundle()
+            info = bundle.localizedInfoDictionary() or bundle.infoDictionary()
+            info["CFBundleName"] = APP_NAME
+        except ModuleNotFoundError:
+            # If Foundation is still not found, the app will run without
+            # setting the bundle name (non-critical macOS-specific feature)
+            # Problem resolves after reactivating the virtual environment.
+            pass
 
     app = PEtabGuiApp(args.petab_yaml)
     sys.exit(app.exec())


### PR DESCRIPTION
(At least on Mac) We got the initial error

```
PEtab_GUI/src/petab_gui/app.py", line 138, in main
    from Foundation import NSBundle  # type: type: ignore[import]
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'Foundation'
```

This resolves after activating and reactivating the venv, thus we pass it on the first use